### PR TITLE
Fix rich text schema naming

### DIFF
--- a/packages/gatsby-source-kontent/src/naming.ts
+++ b/packages/gatsby-source-kontent/src/naming.ts
@@ -200,14 +200,14 @@ const getKontentItemsSchemaNamingConfiguration = (
         `${getKontentItemElementValueTypeNameByType(
           'rich_text',
           config,
-        )}${CONNECTOR}link`,
+        )}${CONNECTOR}image`,
       )
       .replace(
         /__KONTENT_ELEMENT_RICH_TEXT_LINK_VALUE__/g,
         `${getKontentItemElementValueTypeNameByType(
           'rich_text',
           config,
-        )}${CONNECTOR}image`,
+        )}${CONNECTOR}link`,
       )
       // extensions
       .replace(

--- a/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
+++ b/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
@@ -34,8 +34,8 @@ type kontent_item_rich_text_element_value {
   type: String!
   value: String
   modular_content: [kontent_item] @kontent_item_language_link
-  images: [kontent_item_rich_text_element_link]
-  links: [kontent_item_rich_text_element_image]
+  images: [kontent_item_rich_text_element_image]
+  links: [kontent_item_rich_text_element_link]
 }
 
 type kontent_item_number_element_value {
@@ -107,7 +107,7 @@ type kontent_item_taxonomy_element {
   codename: String!
 }
 
-type kontent_item_rich_text_element_link {
+type kontent_item_rich_text_element_image {
   image_id: String!
   url: String!
   description: String
@@ -115,7 +115,7 @@ type kontent_item_rich_text_element_link {
   width: Int!
 }
 
-type kontent_item_rich_text_element_image {
+type kontent_item_rich_text_element_link {
   link_id: String!
   codename: String!
   type: String!


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #144

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Possibly to run query and check schema on preview:

```gql
query MyQuery {
  allKontentItemArticle {
    nodes {
      elements {
        content {
          images {
            description
            height
            image_id
            url
            width
          }
          links {
            codename
            link_id
            url_slug
            type
          }
          modular_content {
            system {
              codename
              id
            }
          }
          name
          type
          value
        }
      }
    }
  }
}
```
