### PR TITLE
Define best practices for preview URLs

### DIFF
--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -139,7 +139,7 @@ One of the content container types is `Listing items`, this type allows to selec
 
 ## Set up Preview URLs
 
-If you are using complex and nested menu navigation in combination with [Preview URLs](https://docs.kontent.ai/tutorials/develop-apps/build-strong-foundation/set-up-preview#a-set-up-content-preview-in-your-project) you might need to have a way to map "preview" URL to the one you have build using schema customization, because in the context of Preview URLs there is only `url slug`, `codename`, `language` and `item ID`, but not information of other elements, or their relationship.
+If you are using complex and nested menu navigation in combination with [Preview URLs](https://docs.kontent.ai/tutorials/develop-apps/build-strong-foundation/set-up-preview#a-set-up-content-preview-in-your-project) you might need to have a way to map the "preview" URL to the one you have built using schema customization because in the context of Preview URLs there is only `url slug`, `codename`, `language` and `item ID`, but not the information of other elements, or their relationship.
 
 > ⚠ Render "preview pages" only in development environment ([`NODE_ENV` is set to `development`](https://www.gatsbyjs.com/docs/environment-variables/#reserved-environment-variables)) and for the pages  that requires preview to prevent build time performance degradation.
 

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -137,4 +137,18 @@ There are multiple content pages used as the content container. Namely `Home pag
 
 One of the content container types is `Listing items`, this type allows to select content type(s) that is/are then used to determine what is about to be queried in the page. To model it in Kontent [Type selector custom element](https://github.com/Simply007/kontent-custom-element-type-selector) is used and then in the application. Then when the application is registering the page components ir loads detail items and [register them under their own route](https://github.com/Simply007/Simply007.github.io/blob/source/gatsby-node.js#L115) with [detail component template](https://github.com/Simply007/Simply007.github.io/blob/source/src/templates/journal-item.js).
 
+## Set up Preview URLs
+
+If you are using complex and nested menu navigation in combination with [Preview URLs](https://docs.kontent.ai/tutorials/develop-apps/build-strong-foundation/set-up-preview#a-set-up-content-preview-in-your-project) you might need to have a way to map "preview" URL to the one you have build using schema customization, because in the context of Preview URLs there is only `url slug`, `codename`, `language` and `item ID`, but not information of other elements, or their relationship.
+
+In a nutshell, you want register routes endpoint like `/preview/<LANGUAGE>/<CODENAME>` by hooking to [`createPages`](https://www.gatsbyjs.com/docs/node-apis/#createPages) Gatsby Node API method and following methods to map your preview URLs to the pre-generated URLs.
+
+- [`createPage`](https://www.gatsbyjs.com/docs/actions/#createPage)
+  - Ideally render "preview pages" only in development environment and for the pages it is necessary to prevent build time performance degradation.
+- Use some custom React based approach to handle redirection
+  - Choose one compatible with [Gatsby Routing mechanism](https://www.gatsbyjs.com/docs/routing/), like `client-only` routes using `@react/router`
+- [`createRedirect`](https://www.gatsbyjs.com/docs/actions/#createRedirect) you could experiment with this action.
+  - Mind the description of the method "Server redirects don’t work out of the box."
+  - Also trying to set redirects on client side (`redirectInBrowse`) as well lead to small blink on development server
+
 ![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/kontent-gatsby-packages/examples/navigation?pixel)

--- a/examples/navigation/README.md
+++ b/examples/navigation/README.md
@@ -141,14 +141,30 @@ One of the content container types is `Listing items`, this type allows to selec
 
 If you are using complex and nested menu navigation in combination with [Preview URLs](https://docs.kontent.ai/tutorials/develop-apps/build-strong-foundation/set-up-preview#a-set-up-content-preview-in-your-project) you might need to have a way to map "preview" URL to the one you have build using schema customization, because in the context of Preview URLs there is only `url slug`, `codename`, `language` and `item ID`, but not information of other elements, or their relationship.
 
-In a nutshell, you want register routes endpoint like `/preview/<LANGUAGE>/<CODENAME>` by hooking to [`createPages`](https://www.gatsbyjs.com/docs/node-apis/#createPages) Gatsby Node API method and following methods to map your preview URLs to the pre-generated URLs.
+> ⚠ Render "preview pages" only in development environment ([`NODE_ENV` is set to `development`](https://www.gatsbyjs.com/docs/environment-variables/#reserved-environment-variables)) and for the pages  that requires preview to prevent build time performance degradation.
+
+In a nutshell, you want register routes endpoint like i.e. `/preview/<LANGUAGE>/<CODENAME>` by hooking to [`createPages`](https://www.gatsbyjs.com/docs/node-apis/#createPages) Gatsby Node API method and use one of the following approaches to map your preview URLs to the publish URLs.
 
 - [`createPage`](https://www.gatsbyjs.com/docs/actions/#createPage)
-  - Ideally render "preview pages" only in development environment and for the pages it is necessary to prevent build time performance degradation.
-- Use some custom React based approach to handle redirection
+  - Just use the same construct, [that is already used for creating production pages](./gatsby-node.js#L82)
+  
+  ```js
+  if(process.env.NODE_ENV === 'development') {
+      createPage({
+        path: `/preview/page/${contentPage.preferred_language}/${contentPage.system.codename}`,
+        component: require.resolve(`./src/templates/content-page.js`),
+        context: {
+          language: contentPage.preferred_language,
+          codename: contentPage.system.codename,
+        },
+      })
+    }
+  ```
+
+- Use some React based approach to handle redirection
   - Choose one compatible with [Gatsby Routing mechanism](https://www.gatsbyjs.com/docs/routing/), like `client-only` routes using `@react/router`
-- [`createRedirect`](https://www.gatsbyjs.com/docs/actions/#createRedirect) you could experiment with this action.
-  - Mind the description of the method "Server redirects don’t work out of the box."
-  - Also trying to set redirects on client side (`redirectInBrowse`) as well lead to small blink on development server
+- [`createRedirect`](https://www.gatsbyjs.com/docs/actions/#createRedirect)
+  - Mind the description of the action "Server redirects don’t work out of the box".
+  - Also defining redirects on client side (option `redirectInBrowse`) lead to small delay/blink on development server from 404 to redirected page.
 
 ![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/kontent-gatsby-packages/examples/navigation?pixel)


### PR DESCRIPTION
### Motivation

Extension of navigation example.

Defines possibilities and options when defining preview URLs for complex precalculated URL.

Related to https://github.com/Kentico/gatsby-starter-kontent-lumen/pull/14

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
