### PR TITLE
Add support for gatsby-plugin-image

### DIFF
--- a/packages/gatsby-kontent-components/README.md
+++ b/packages/gatsby-kontent-components/README.md
@@ -22,7 +22,7 @@ Images from Kentico Kontent can be displayed using the `ImageElement` component.
 
 The component takes all [the `GatsbyImage` props](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#gatsbyimage), as well as the following properties. All are optional except `image`:
 
-- `image`: the `image` object. This should include `src`, `width` and `height`.
+- `image`: the `image` object. This should include `url`, `width` and `height`.
 - `layout`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#layout)
 - `width`/`height`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#widthheight)
 - `aspectRatio`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#aspectratio)

--- a/packages/gatsby-kontent-components/README.md
+++ b/packages/gatsby-kontent-components/README.md
@@ -11,8 +11,21 @@ The package containing React components useful when processing Kontent data to t
 ## Install
 
 ```sh
-npm install @kentico/gatsby-kontent-components
+npm install @kentico/gatsby-kontent-components gatsby-plugin-image
 ```
+
+## Image element component
+
+Images from Kentico Kontent can be displayed using the `ImageElement` component. This wraps the `GatsbyImage` component from [gatsby-plugin-image](https://www.gatsbyjs.com/docs/how-to/images-and-media/using-gatsby-plugin-image/), so ensure that you also install that plugin. This component will give the best experience for your users, as it includes responsive srcset, blur-up, lazy loading and many other performance optimizations. [Automatic format optimization](https://docs.kontent.ai/reference/image-transformation#a-automatic-format-selection) is always enabled. In many cases it can improve Lighthouse scores by 10-20 points.
+
+The component takes all [the `GatsbyImage` props](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#gatsbyimage), as well as the following properties. All are optional except `image`:
+
+- `image`: the `image` object. This should include `src`, `width` and `height`.
+- `layout`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#layout)
+- `width`/`height`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#widthheight)
+- `aspectRatio`: see [the `gatsby-plugin-image` docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image#aspectratio)
+- `backgroundColor`: displayed as a placeholder while the image loads
+- `options`: an object containing options passed to [the Kontent Image Transformation API](https://docs.kontent.ai/reference/image-transformation). Supported options: `fit`, `quality`, `lossless`.
 
 ## Rich text element component
 
@@ -23,7 +36,7 @@ This package should make the usage easier. Basically by loading the rich text da
 > Complete showcase could be found in [rich-text.js](../../site/src/pages/rich-text.js) in the development site.
 
 ```jsx
-import { RichTextElement } from "@kentico/gatsby-kontent-components"
+import { RichTextElement, ImageElement } from "@kentico/gatsby-kontent-components"
 
 // ...
 
@@ -34,14 +47,14 @@ import { RichTextElement } from "@kentico/gatsby-kontent-components"
       linkedItems={richTextElement.modular_content}
       resolveImage={image => {
         return (
-          <img
-            src={image.url}
+          <ImageElement
+            image={image}
             alt={image.description ? image.description : image.name}
-            width="200"
+            width={200}
           />
         )
       }}
-      resolveLink={(link, domNode) => {
+      resolveLink={(link, domNode) =>
         const parentItemType = contextData.type // It is possible to use external data for resolution
         return (
           <Link to={`/${link.type}/partner/${parentItemType}/${link.url_slug}`}>

--- a/packages/gatsby-kontent-components/README.md
+++ b/packages/gatsby-kontent-components/README.md
@@ -14,7 +14,7 @@ The package containing React components useful when processing Kontent data to t
 npm install @kentico/gatsby-kontent-components gatsby-plugin-image
 ```
 
-Also, add `gatsby-plugin-image` to `module.exports` section in `gatsby-config.js`.
+Also, add `gatsby-plugin-image` to `plugins` array in `gatsby-config.js`.
 
 ## <a name="image-element-component">Image element component</a>
 

--- a/packages/gatsby-kontent-components/README.md
+++ b/packages/gatsby-kontent-components/README.md
@@ -14,7 +14,9 @@ The package containing React components useful when processing Kontent data to t
 npm install @kentico/gatsby-kontent-components gatsby-plugin-image
 ```
 
-## Image element component
+Also, add `gatsby-plugin-image` to `module.exports` section in `gatsby-config.js`.
+
+## <a name="image-element-component">Image element component</a>
 
 Images from Kentico Kontent can be displayed using the `ImageElement` component. This wraps the `GatsbyImage` component from [gatsby-plugin-image](https://www.gatsbyjs.com/docs/how-to/images-and-media/using-gatsby-plugin-image/), so ensure that you also install that plugin. This component will give the best experience for your users, as it includes responsive srcset, blur-up, lazy loading and many other performance optimizations. [Automatic format optimization](https://docs.kontent.ai/reference/image-transformation#a-automatic-format-selection) is always enabled. In many cases it can improve Lighthouse scores by 10-20 points.
 
@@ -87,7 +89,8 @@ If you don't need to resolve anything, you could just provide `value` property.
 If you want to resolve images pass `images` and `resolveImage` properties.
 
 - `images` **have to contain at least `image_id` property**
-- `resolveImage` has one parameter `image` basically containing one record from `images` array
+- `resolveImage` has one parameter `image` usually containing one record from `images` array
+- when resolving images in Rich text element using [Image element component]((#image-element-component)), `image` object must follow data contract defined in [Image element component](#image-element-component) section. Moreover, for correct resolution, the additional `image_id` identifier of the image is mandatory, as well.
 
 #### Links to content items
 

--- a/packages/gatsby-kontent-components/package.json
+++ b/packages/gatsby-kontent-components/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "2.16.0",
     "@typescript-eslint/parser": "2.16.0",
     "eslint": "6.8.0",
+    "gatsby-plugin-image": "^1.0.0-next.3",
     "jest": "^24.9.0",
     "jest-ts-auto-mock": "^1.0.11",
     "prettier": "1.19.1",
@@ -54,6 +55,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
+    "gatsby-plugin-image": "^1.0.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   },

--- a/packages/gatsby-kontent-components/src/image-element/get-gatsby-image-data.ts
+++ b/packages/gatsby-kontent-components/src/image-element/get-gatsby-image-data.ts
@@ -1,0 +1,67 @@
+import {
+  IGatsbyImageData,
+  getImageData,
+  Layout,
+  IGetImageDataArgs,
+} from 'gatsby-plugin-image';
+import { ImageItem } from '.';
+
+export interface ImageOptions {
+  fit?: 'crop' | 'clip' | 'scale';
+  quality?: number;
+  lossless?: boolean;
+}
+
+export interface GetGatsbyImageDataProps {
+  image: ImageItem;
+  width?: number;
+  height?: number;
+  layout?: Layout;
+  backgroundColor?: string;
+  sizes?: string;
+  aspectRatio?: number;
+  options?: ImageOptions;
+}
+
+export function getGatsbyImageData({
+  image,
+  backgroundColor,
+  options = {},
+  layout = `constrained`,
+  ...props
+}: GetGatsbyImageDataProps): IGatsbyImageData {
+  const urlBuilder: IGetImageDataArgs<ImageOptions>['urlBuilder'] = ({
+    baseUrl,
+    width,
+    height,
+    options: { quality, fit = 'crop', lossless },
+  }): string => {
+    const props = [
+      ['w', width],
+      ['h', height],
+      ['auto', 'format'],
+      ['bg', backgroundColor],
+      ['q', quality],
+      ['lossless', lossless],
+      ['fit', fit],
+    ];
+    const query = props
+      .filter(([, val]) => typeof val !== 'undefined')
+      .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
+      .join('&');
+
+    return `${baseUrl}?${query}`;
+  };
+
+  return getImageData({
+    baseUrl: image.url,
+    sourceWidth: image.width,
+    sourceHeight: image.height,
+    layout,
+    urlBuilder,
+    backgroundColor,
+    pluginName: 'gatsby-kontent-components',
+    options,
+    ...props,
+  });
+}

--- a/packages/gatsby-kontent-components/src/image-element/index.tsx
+++ b/packages/gatsby-kontent-components/src/image-element/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { GatsbyImageProps, GatsbyImage } from 'gatsby-plugin-image';
+import {
+  getGatsbyImageData,
+  GetGatsbyImageDataProps,
+} from './get-gatsby-image-data';
+
+export interface ImageItem {
+  image_id: string;
+  url: string;
+  description?: string;
+  name?: string;
+  height: number;
+  width: number;
+  type?: string;
+}
+
+export interface ImageElementProps
+  extends GetGatsbyImageDataProps,
+    Omit<GatsbyImageProps, 'image' | 'alt'> {
+  alt?: string;
+}
+
+export const ImageElement: React.FC<ImageElementProps> = function ImageElement({
+  image,
+  width,
+  height,
+  layout,
+  backgroundColor,
+  sizes,
+  aspectRatio,
+  options,
+  alt,
+  ...props
+}): JSX.Element {
+  const imageData = getGatsbyImageData({
+    image,
+    width,
+    height,
+    layout,
+    backgroundColor,
+    sizes,
+    aspectRatio,
+    options,
+  });
+  alt = alt ?? image.description ?? '';
+  return <GatsbyImage image={imageData} {...props} alt={alt} />;
+};

--- a/packages/gatsby-kontent-components/src/index.ts
+++ b/packages/gatsby-kontent-components/src/index.ts
@@ -1,3 +1,3 @@
-import { RichTextElement } from './rich-text-element';
+export { RichTextElement } from './rich-text-element';
 
-export { RichTextElement };
+export { ImageElement } from './image-element';

--- a/packages/gatsby-kontent-components/src/rich-text-element/index.tsx
+++ b/packages/gatsby-kontent-components/src/rich-text-element/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import parseHTML, { DomElement, domToReact } from 'html-react-parser';
+import { ImageItem } from '../image-element';
 
 const IMAGE_ID_ATTRIBUTE_IDENTIFIER = 'data-image-id';
 const LINKED_ITEM_ID_ATTRIBUTE_IDENTIFIER = 'data-item-id';
@@ -9,35 +10,41 @@ interface Props {
   value: string;
   linkedItems?: any[];
   resolveLinkedItem?: Function;
-  images?: any[];
-  resolveImage?: Function;
+  images?: ImageItem[];
+  resolveImage?: ((image?: ImageItem) => JSX.Element) | undefined;
   links?: any[];
   resolveLink?: Function;
   resolveDomNode?: Function;
 }
 
 const isLinkedItem = (domNode: DomElement): boolean =>
-  domNode.name === 'object' && domNode.attribs?.type === 'application/kenticocloud';
+  domNode.name === 'object' &&
+  domNode.attribs?.type === 'application/kenticocloud';
 
 const isImage = (domNode: DomElement): boolean =>
-  domNode.name === 'figure' && typeof domNode.attribs?.[IMAGE_ID_ATTRIBUTE_IDENTIFIER] !== 'undefined'
+  domNode.name === 'figure' &&
+  typeof domNode.attribs?.[IMAGE_ID_ATTRIBUTE_IDENTIFIER] !== 'undefined';
 
 const isLink = (domNode: DomElement): boolean =>
-  domNode.name === 'a' && typeof domNode.attribs?.[LINKED_ITEM_ID_ATTRIBUTE_IDENTIFIER] !== 'undefined'
+  domNode.name === 'a' &&
+  typeof domNode.attribs?.[LINKED_ITEM_ID_ATTRIBUTE_IDENTIFIER] !== 'undefined';
 
 const replaceNode = (
   domNode: DomElement,
   linkedItems: any[] | undefined,
   resolveLinkedItem: Function | undefined,
   images: any[] | undefined,
-  resolveImage: Function | undefined,
+  resolveImage: ((image?: ImageItem) => JSX.Element) | undefined,
   links: any[] | undefined,
   resolveLink: Function | undefined,
-  resolveDomNode: Function | undefined): void => {
+  resolveDomNode: Function | undefined,
+): JSX.Element | void => {
   if (resolveLinkedItem && linkedItems) {
     if (isLinkedItem(domNode)) {
-      const codeName = domNode.attribs?.["data-codename"];
-      const linkedItem = linkedItems.find(item => item.system.codename === codeName);
+      const codeName = domNode.attribs?.['data-codename'];
+      const linkedItem = linkedItems.find(
+        item => item.system.codename === codeName,
+      );
       return resolveLinkedItem(linkedItem);
     }
   }
@@ -63,17 +70,35 @@ const replaceNode = (
   }
 };
 
-const RichTextElement = ({ value, linkedItems, resolveLinkedItem, images, resolveImage, links, resolveLink, resolveDomNode}: Props): JSX.Element => {
+const RichTextElement = ({
+  value,
+  linkedItems,
+  resolveLinkedItem,
+  images,
+  resolveImage,
+  links,
+  resolveLink,
+  resolveDomNode,
+}: Props): JSX.Element => {
   const result = parseHTML(value, {
-    replace: (domNode: DomElement) => replaceNode(domNode, linkedItems, resolveLinkedItem, images, resolveImage, links, resolveLink, resolveDomNode),
+    replace: (domNode: DomElement) =>
+      replaceNode(
+        domNode,
+        linkedItems,
+        resolveLinkedItem,
+        images,
+        resolveImage,
+        links,
+        resolveLink,
+        resolveDomNode,
+      ),
   });
 
   if (result as JSX.Element[]) {
-    return (<>{result}</>);
+    return <>{result}</>;
   }
 
   return result as JSX.Element;
-}
+};
 
 export { RichTextElement };
-

--- a/packages/gatsby-kontent-components/tests/__snapshots__/rich-text-emelemt.spec.tsx.snap
+++ b/packages/gatsby-kontent-components/tests/__snapshots__/rich-text-emelemt.spec.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<ImageElement /> renders the correct image 1`] = `
+Object {
+  "sizes": "(min-width: 500px) 500px, 100vw",
+  "src": "https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=500&h=500&auto=format&fit=crop",
+  "srcSet": "https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=320&h=320&auto=format&fit=crop 320w,https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=500&h=500&auto=format&fit=crop 500w",
+}
+`;
+
 exports[`<RichTextElement/> Complex rich-text value - render properly no resolution 1`] = `
 Array [
   <p>

--- a/packages/gatsby-kontent-components/tests/rich-text-emelemt.spec.tsx
+++ b/packages/gatsby-kontent-components/tests/rich-text-emelemt.spec.tsx
@@ -1,92 +1,135 @@
-import React from "react";
-import TestRenderer from "react-test-renderer";
-import { RichTextElement } from "../src"
+/* eslint-disable @typescript-eslint/camelcase */
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { ImageElement, RichTextElement } from '../src';
+import { getSrc } from 'gatsby-plugin-image';
+import { getGatsbyImageData } from '../src/image-element/get-gatsby-image-data';
 
-
-
-const sampleComplexValue = "<p>This is Ondřej Chrastina - Developer Advocate with <a href=\"https://kontent.ai\" data-new-window=\"true\" target=\"_blank\" rel=\"noopener noreferrer\">Kentico Kontent</a>.</p>\n<figure data-asset-id=\"d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88\" data-image-id=\"d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88\"><img src=\"https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg\" data-asset-id=\"d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88\" data-image-id=\"d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88\" alt=\"\"></figure>\n<p>He likes to do web sites. This is his latest project:</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"ondrej_chrastina_tech\"></object>\n<p><br>\nHe also likes OSS. This is his latest repository:</p>\n<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"simply007_kontent_gatsby_benchmark\"></object>\n<p><br>\nOn some projects, he was cooperating with <a data-item-id=\"2b805947-7ca5-4e6a-baa5-734a91f3cfa2\" href=\"\">John Doe</a>.</p>\n<p>You could take a look at their&nbsp;<a href=\"https://google.com\" title=\"sample link\">latest project</a>.</p>\n<table><tbody>\n  <tr><td>col1</td><td>col2</td></tr>\n  <tr><td>data1</td><td>data2</td></tr>\n  <tr><td>data3</td><td>data4</td></tr>\n</tbody></table>";
+const sampleComplexValue =
+  '<p>This is Ondřej Chrastina - Developer Advocate with <a href="https://kontent.ai" data-new-window="true" target="_blank" rel="noopener noreferrer">Kentico Kontent</a>.</p>\n<figure data-asset-id="d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88" data-image-id="d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88"><img src="https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg" data-asset-id="d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88" data-image-id="d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88" alt=""></figure>\n<p>He likes to do web sites. This is his latest project:</p>\n<object type="application/kenticocloud" data-type="item" data-rel="link" data-codename="ondrej_chrastina_tech"></object>\n<p><br>\nHe also likes OSS. This is his latest repository:</p>\n<object type="application/kenticocloud" data-type="item" data-rel="link" data-codename="simply007_kontent_gatsby_benchmark"></object>\n<p><br>\nOn some projects, he was cooperating with <a data-item-id="2b805947-7ca5-4e6a-baa5-734a91f3cfa2" href="">John Doe</a>.</p>\n<p>You could take a look at their&nbsp;<a href="https://google.com" title="sample link">latest project</a>.</p>\n<table><tbody>\n  <tr><td>col1</td><td>col2</td></tr>\n  <tr><td>data1</td><td>data2</td></tr>\n  <tr><td>data3</td><td>data4</td></tr>\n</tbody></table>';
 const links = [
   {
-    "url_slug": "john-doe",
-    "type": "person",
-    "link_id": "2b805947-7ca5-4e6a-baa5-734a91f3cfa2",
-    "codename": "john_doe"
-  }
+    url_slug: 'john-doe',
+    type: 'person',
+    link_id: '2b805947-7ca5-4e6a-baa5-734a91f3cfa2',
+    codename: 'john_doe',
+  },
 ];
 const images = [
   {
-    "description": null,
-    "height": 500,
-    "image_id": "d32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88",
-    "url": "https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg",
-    "width": 500
-  }
+    description: null,
+    height: 500,
+    image_id: 'd32b8ad5-0cf4-47a8-8b53-ed4a1e80dc88',
+    url:
+      'https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg',
+    width: 500,
+  },
 ];
 const linkedItems = [
   {
-    "__typename": "kontent_item_website",
-    "system": {
-      "codename": "ondrej_chrastina_tech"
+    __typename: 'kontent_item_website',
+    system: {
+      codename: 'ondrej_chrastina_tech',
     },
-    "elements": {
-      "name": {
-        "value": "ondrej.chrastina.tech"
+    elements: {
+      name: {
+        value: 'ondrej.chrastina.tech',
       },
-      "slug": {
-        "value": "ondrej-chrastina-tech"
+      slug: {
+        value: 'ondrej-chrastina-tech',
       },
-      "summary": {
-        "value": "Ondřej Chrastina's personal site"
+      summary: {
+        value: "Ondřej Chrastina's personal site",
       },
-      "url": {
-        "value": "https://ondrej.chrastina.tech"
+      url: {
+        value: 'https://ondrej.chrastina.tech',
       },
-      "source_repository": {
-        "value": [
+      source_repository: {
+        value: [
           {
-            "__typename": "kontent_item_repository",
-            "elements": {
-              "slug": {
-                "value": "simply007-simply007-github-io"
-              }
-            }
-          }
-        ]
-      }
-    }
+            __typename: 'kontent_item_repository',
+            elements: {
+              slug: {
+                value: 'simply007-simply007-github-io',
+              },
+            },
+          },
+        ],
+      },
+    },
   },
   {
-    "__typename": "kontent_item_repository",
-    "system": {
-      "codename": "simply007_kontent_gatsby_benchmark"
+    __typename: 'kontent_item_repository',
+    system: {
+      codename: 'simply007_kontent_gatsby_benchmark',
     },
-    "elements": {
-      "name": {
-        "value": "Simply007/kontent-gatsby-benchmark"
+    elements: {
+      name: {
+        value: 'Simply007/kontent-gatsby-benchmark',
       },
-      "slug": {
-        "value": "simply007-kontent-gatsby-benchmark"
+      slug: {
+        value: 'simply007-kontent-gatsby-benchmark',
       },
-      "summary": {
-        "value": "Example site for Kontent as a source for \"Will It Build\". Should/Will be generalized into e.g. a theme."
+      summary: {
+        value:
+          'Example site for Kontent as a source for "Will It Build". Should/Will be generalized into e.g. a theme.',
       },
-      "url": {
-        "value": "https://github.com/Simply007/kontent-gatsby-benchmark"
-      }
-    }
-  }
+      url: {
+        value: 'https://github.com/Simply007/kontent-gatsby-benchmark',
+      },
+    },
+  },
 ];
 
-describe("<RichTextElement/>", () => {
+describe('<ImageElement />', () => {
+  it('generates the correct image src', () => {
+    const data = getGatsbyImageData({ image: images[0] });
+    expect(data.images.fallback.src).toEqual(
+      'https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=500&h=500&auto=format&fit=crop',
+    );
+  });
+  it('generates the srcset', () => {
+    const data = getGatsbyImageData({ image: images[0] });
+    expect(data.images.fallback.srcSet).toMatchInlineSnapshot(`
+      "https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=320&h=320&auto=format&fit=crop 320w,
+      https://assets-us-01.kc-usercontent.com:443/0fe3ab32-97a8-005d-6928-eda983ea70a5/44299668-b37b-4224-a115-1fd66f7d7b36/Yprofile.jpg?w=500&h=500&auto=format&fit=crop 500w"
+    `);
+  });
+
+  it('generates the correct dimensions', () => {
+    const data = getGatsbyImageData({
+      image: images[0],
+      width: 200,
+      aspectRatio: 2 / 1,
+    });
+    expect(data.width).toEqual(200);
+    expect(data.height).toEqual(100);
+  });
+
+  it('renders the correct image', () => {
+    const testRenderer = TestRenderer.create(
+      <ImageElement image={images[0]} />,
+    );
+    expect(
+      testRenderer.root.findByProps({ 'data-main-image': '' }).props.fallback,
+    ).toMatchSnapshot();
+  });
+});
+
+describe('<RichTextElement/>', () => {
   it('Empty rich-text value - render properly', () => {
-    const testRenderer = TestRenderer.create(<RichTextElement value="<p><br></p>" />)
+    const testRenderer = TestRenderer.create(
+      <RichTextElement value="<p><br></p>" />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
+  });
 
   it('Complex rich-text value - render properly no resolution', () => {
-    const testRenderer = TestRenderer.create(<RichTextElement value={sampleComplexValue} />)
+    const testRenderer = TestRenderer.create(
+      <RichTextElement value={sampleComplexValue} />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
+  });
 
   it('Resolve images', () => {
     const testRenderer = TestRenderer.create(
@@ -99,10 +142,11 @@ describe("<RichTextElement/>", () => {
             alt={image.description ? image.description : image.name}
             width="200"
           />
-        )} />
-    )
+        )}
+      />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
+  });
 
   it('Resolve links', () => {
     const testRenderer = TestRenderer.create(
@@ -110,15 +154,17 @@ describe("<RichTextElement/>", () => {
         value={sampleComplexValue}
         links={links}
         resolveLink={(link, domNode): JSX.Element => {
-          return ( // normally a Link component from gatsby package would be used
+          return (
+            // normally a Link component from gatsby package would be used
             <a href={`/${link.type}/${link.url_slug}`}>
               {domNode.children[0].data}
             </a>
-          )
-        }} />
-    )
+          );
+        }}
+      />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
+  });
 
   it('Resolve linked items', () => {
     const testRenderer = TestRenderer.create(
@@ -126,27 +172,24 @@ describe("<RichTextElement/>", () => {
         value={sampleComplexValue}
         linkedItems={linkedItems}
         resolveLinkedItem={(linkedItem): JSX.Element => {
-          return <pre>{JSON.stringify(linkedItem, undefined, 2)}</pre>
-        }} />
-    )
+          return <pre>{JSON.stringify(linkedItem, undefined, 2)}</pre>;
+        }}
+      />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
+  });
 
   it('Resolve geneal node - wrap table element', () => {
     const testRenderer = TestRenderer.create(
       <RichTextElement
         value={sampleComplexValue}
         resolveDomNode={(domNode, domToReact): JSX.Element => {
-          if (domNode.name === "table") {
-            return (
-              <div className="table-wrapper">
-                {domToReact([domNode])}
-              </div>
-            );
+          if (domNode.name === 'table') {
+            return <div className="table-wrapper">{domToReact([domNode])}</div>;
           }
         }}
-         />
-    )
+      />,
+    );
     expect(testRenderer.toJSON()).toMatchSnapshot();
-  })
-})
+  });
+});

--- a/packages/gatsby-source-kontent/package.json
+++ b/packages/gatsby-source-kontent/package.json
@@ -55,7 +55,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.32.3"
+    "gatsby": "^2.32.3 || ^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gatsby-source-kontent/package.json
+++ b/packages/gatsby-source-kontent/package.json
@@ -44,7 +44,7 @@
     "@typescript-eslint/parser": "2.16.0",
     "cross-env": "^7.0.2",
     "eslint": "6.8.0",
-    "gatsby": "2.28.0",
+    "gatsby": "^2.32.3",
     "gatsby-core-utils": "^1.1.1",
     "jest": "^24.9.0",
     "jest-ts-auto-mock": "^1.0.11",
@@ -55,7 +55,7 @@
     "typescript": "^3.7.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.20.8"
+    "gatsby": "^2.32.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gatsby-source-kontent/src/template.items.schema.gql
+++ b/packages/gatsby-source-kontent/src/template.items.schema.gql
@@ -30,7 +30,8 @@ type __KONTENT_ITEM_RICH_TEXT_ELEMENT__ {
   name: String!
   type: String!
   value: String
-  modular_content: [__KONTENT_ITEM_INTERFACE__] @__KONTENT_ITEM_LANGUAGE_EXTENSION__
+  modular_content: [__KONTENT_ITEM_INTERFACE__]
+    @__KONTENT_ITEM_LANGUAGE_EXTENSION__
   images: [__KONTENT_ELEMENT_RICH_TEXT_IMAGE_VALUE__]
   links: [__KONTENT_ELEMENT_RICH_TEXT_LINK_VALUE__]
 }
@@ -110,6 +111,7 @@ type __KONTENT_ELEMENT_RICH_TEXT_IMAGE_VALUE__ {
   description: String
   height: Int!
   width: Int!
+  type: String!
 }
 
 type __KONTENT_ELEMENT_RICH_TEXT_LINK_VALUE__ {

--- a/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
+++ b/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
@@ -48,7 +48,8 @@ type kontent_item_rich_text_element_value {
   name: String!
   type: String!
   value: String
-  modular_content: [kontent_item] @kontent_item_language_link
+  modular_content: [kontent_item]
+    @kontent_item_language_link
   images: [kontent_item_rich_text_element_image]
   links: [kontent_item_rich_text_element_link]
 }
@@ -128,6 +129,7 @@ type kontent_item_rich_text_element_image {
   description: String
   height: Int!
   width: Int!
+  type: String!
 }
 
 type kontent_item_rich_text_element_link {

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -4,7 +4,7 @@
  * See: https://www.gatsbyjs.org/docs/gatsby-config/
  */
 
-require('dotenv').config({ path: '.env.development' })
+require("dotenv").config({ path: ".env.development" })
 
 module.exports = {
   plugins: [
@@ -12,7 +12,9 @@ module.exports = {
       resolve: "@kentico/gatsby-source-kontent",
       options: {
         projectId: process.env.KONTENT_PROJECT_ID,
-        languageCodenames: process.env.KONTENT_LANGUAGE_CODENAMES.split(',').map(lang => lang.trim()),
+        languageCodenames: process.env.KONTENT_LANGUAGE_CODENAMES.split(
+          ","
+        ).map(lang => lang.trim()),
         usePreviewUrl: !!process.env.KONTENT_PREVIEW_ENABLED,
         authorizationKey: process.env.KONTENT_PREVIEW_ENABLED
           ? process.env.KONTENT_PREVIEW_KEY
@@ -22,10 +24,12 @@ module.exports = {
         includeTypes: true,
         proxy: {
           deliveryDomain: process.env.KONTENT_DELIVERY_DOMAIN || undefined,
-          previewDeliveryDomain: process.env.KONTENT_PREVIEW_DELIVERY_DOMAIN || undefined
-        }
+          previewDeliveryDomain:
+            process.env.KONTENT_PREVIEW_DELIVERY_DOMAIN || undefined,
+        },
       },
     },
-    "@rshackleton/gatsby-transformer-kontent-image"
+    "@rshackleton/gatsby-transformer-kontent-image",
+    "gatsby-plugin-image",
   ],
 }

--- a/site/package.json
+++ b/site/package.json
@@ -27,6 +27,7 @@
     "@rshackleton/gatsby-transformer-kontent-image": "^2.1.0",
     "gatsby": "^2.28.0",
     "gatsby-image": "^2.4.7",
+    "gatsby-plugin-image": "^1.0.0-next.3",
     "qs": "^6.9.4",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/site/src/pages/author.js
+++ b/site/src/pages/author.js
@@ -1,70 +1,130 @@
 import React from "react"
 import { graphql } from "gatsby"
-import { stringify } from "qs";
-import { ImageUrlBuilder } from '@kentico/kontent-delivery';
-import Img from "gatsby-image";
+import { stringify } from "qs"
+import { ImageElement } from "@kentico/gatsby-kontent-components"
+import { ImageUrlBuilder } from "@kentico/kontent-delivery"
+import Img from "gatsby-image"
 
 const Author = ({ data }) => {
-
   if (!data.author.elements.avatar_image.value.length) {
     return <pre>Author avatar note set.</pre>
   }
 
-  const showcaseWidth = 250;
+  const showcaseWidth = 250
 
-  const avatar = data.author.elements.avatar_image.value[0];
+  const avatar = data.author.elements.avatar_image.value[0]
 
   const rectSelection = [
-    160, 70, 0.7, 0.9 // https://docs.kontent.ai/reference/image-transformation#a-source-rectangle-region
-  ];
+    160,
+    70,
+    0.7,
+    0.9, // https://docs.kontent.ai/reference/image-transformation#a-source-rectangle-region
+  ]
   const imageQuery = {
-    rect: rectSelection.join(','),
-    w: 230 // https://docs.kontent.ai/reference/image-transformation#a-image-width
-  };
+    rect: rectSelection.join(","),
+    w: 230, // https://docs.kontent.ai/reference/image-transformation#a-image-width
+  }
 
   // https://github.com/Kentico/kontent-delivery-sdk-js/blob/master/DOCS.md#image-transformations
   const deliverySDKTransformedUrl = new ImageUrlBuilder(avatar.url)
     .withRectangleCrop(...rectSelection)
-    .withWidth(imageQuery.w);
+    .withWidth(imageQuery.w)
 
   return (
     <>
       <header>
         <h1>{data.author.elements.name.value}</h1>
       </header>
+      <section>
+        <ImageElement
+          image={avatar}
+          width={800}
+          height={200}
+          backgroundColor="#bbbbbb"
+          alt={avatar.description}
+        />
+        <p>
+          This uses the <code>ImageElement</code> component to display a
+          responsive image.
+        </p>
+      </section>
 
-      <article style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}>
-
+      <article
+        style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}
+      >
         <section style={{ padding: "1em", maxWidth: showcaseWidth }}>
           <img
             src={avatar.url}
             alt={avatar.description || "Author avatar image"}
-            width="200px" />
-          <p>This is the basic loading of the asset in full size and setting its width right in <tt>img</tt> tag (don't do that).</p>
+            width="200px"
+          />
+          <p>
+            This is the basic loading of the asset in full size and setting its
+            width right in <tt>img</tt> tag (don't do that).
+          </p>
         </section>
         <section style={{ padding: "1em", maxWidth: showcaseWidth }}>
           <Img
             fluid={avatar.fluid}
-            description={avatar.description || "Author avatar image"} />
+            description={avatar.description || "Author avatar image"}
+          />
 
-          <p>Showcase using <a href="https://github.com/rshackleton/gatsby-packages/tree/master/packages/gatsby-transformer-kontent-image#readme">community-based image transformer plugin</a> by <a href="https://github.com/rshackleton">Richard Shackleton.</a> Showcase specifically showcasing <a href="https://www.gatsbyjs.org/packages/gatsby-image/#fluid-queries">fluid query</a> of <a href="https://www.gatsbyjs.org/packages/gatsby-image/">gatsby-image</a> package.</p>
-          <strong>See the "blur up" effect when you are loading the site.</strong>
+          <p>
+            Showcase using{" "}
+            <a href="https://github.com/rshackleton/gatsby-packages/tree/master/packages/gatsby-transformer-kontent-image#readme">
+              community-based image transformer plugin
+            </a>{" "}
+            by <a href="https://github.com/rshackleton">Richard Shackleton.</a>{" "}
+            Showcase specifically showcasing{" "}
+            <a href="https://www.gatsbyjs.org/packages/gatsby-image/#fluid-queries">
+              fluid query
+            </a>{" "}
+            of{" "}
+            <a href="https://www.gatsbyjs.org/packages/gatsby-image/">
+              gatsby-image
+            </a>{" "}
+            package.
+          </p>
+          <strong>
+            See the "blur up" effect when you are loading the site.
+          </strong>
         </section>
       </article>
 
-      <article style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}>
+      <article
+        style={{ display: "flex", flexWrap: "wrap", alignItems: "flex-end" }}
+      >
         <section style={{ padding: "1em", maxWidth: showcaseWidth }}>
           <img
             src={`${avatar.url}?${stringify(imageQuery, { encode: false })}`}
-            alt={avatar.description || "Author avatar image"} />
-          <p>Showcase using <a href="https://docs.kontent.ai/reference/image-transformation">Kontent Image transformation API</a> and <a href="https://www.npmjs.com/package/qs">qs npm package.</a> for query string construction.</p>
+            alt={avatar.description || "Author avatar image"}
+          />
+          <p>
+            Showcase using{" "}
+            <a href="https://docs.kontent.ai/reference/image-transformation">
+              Kontent Image transformation API
+            </a>{" "}
+            and <a href="https://www.npmjs.com/package/qs">qs npm package.</a>{" "}
+            for query string construction.
+          </p>
         </section>
 
         <section style={{ padding: "1em", maxWidth: showcaseWidth }}>
           <img
             src={deliverySDKTransformedUrl.getUrl()}
-            alt={avatar.description || "Author avatar image"} />
-          <p>Showcase using <a href="https://docs.kontent.ai/reference/image-transformation">Kontent Image transformation API</a> and <a href="https://github.com/Kentico/kontent-delivery-sdk-js/blob/master/DOCS.md#image-transformations">Delivery SDK</a> for query string construction.</p>
+            alt={avatar.description || "Author avatar image"}
+          />
+          <p>
+            Showcase using{" "}
+            <a href="https://docs.kontent.ai/reference/image-transformation">
+              Kontent Image transformation API
+            </a>{" "}
+            and{" "}
+            <a href="https://github.com/Kentico/kontent-delivery-sdk-js/blob/master/DOCS.md#image-transformations">
+              Delivery SDK
+            </a>{" "}
+            for query string construction.
+          </p>
         </section>
       </article>
     </>
@@ -81,6 +141,10 @@ export const query = graphql`
         avatar_image {
           value {
             url
+            width
+            height
+            description
+            type
             fluid(maxWidth: 200) {
               ...KontentAssetFluid
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3883,13 +3883,6 @@ axios@^0.19.2:
   dependencies:
     follow-redirects "1.5.10"
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3934,6 +3927,11 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
+babel-jsx-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.0.1.tgz#f2d171cba526594e7d69e9893d634502cf950f07"
+  integrity sha512-Qph/atlQiSvfmkoIZ9VA+t8dA0ex2TwL37rkhLT9YLJdhaTMZ2HSM2QGzbqjLWanKA+I3wRQJjjhtuIEgesuLw==
+
 babel-loader@^8.1.0:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
@@ -3943,13 +3941,6 @@ babel-loader@^8.1.0:
     loader-utils "^1.4.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
-
-babel-plugin-add-module-exports@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.3.3.tgz#b9f7c0a93b989170dce07c3e97071a905a13fc29"
-  integrity sha512-hC37mm7aAdEb1n8SgggG8a1QuhZapsY/XLCi4ETSH6AVjXBCWEa50CXlOsAMPPWLnSx5Ns6mzz39uvuseh0Xjg==
-  optionalDependencies:
-    chokidar "^2.0.4"
 
 babel-plugin-add-module-exports@^1.0.4:
   version "1.0.4"
@@ -3980,7 +3971,7 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-lodash@3.3.4, babel-plugin-lodash@^3.3.4:
+babel-plugin-lodash@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
   integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
@@ -4000,10 +3991,15 @@ babel-plugin-macros@^2.8.0:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-remove-graphql-queries@^2.12.0, babel-plugin-remove-graphql-queries@^2.16.0:
+babel-plugin-remove-graphql-queries@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.16.0.tgz#8abb88ee9f0a5edaef667663657091aa34cdc5c4"
   integrity sha512-sUmAjyA1JUHIWOzV7h1+sLAplNWUQlC6A1Cs2Xmpi/tHcHjHSpI4R5y5Um82WjiT7IHV2LfBKqL/qpyGeXky5w==
+
+babel-plugin-remove-graphql-queries@^3.0.0-next.0:
+  version "3.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-3.0.0-next.0.tgz#a008368f9df9d3a0d191ec74dbcd7bf34acfaf8c"
+  integrity sha512-N8ldONgeFH+zEXi5r+galHmM6visOvtkwrTlRDfD+wPC/jBkjNaYAMmMpkT8uIvvQQ0n+8hii6Uy56HGJfj/Yg==
 
 babel-plugin-transform-react-remove-prop-types@^0.4.24:
   version "0.4.24"
@@ -4030,26 +4026,6 @@ babel-preset-gatsby@^0.12.1:
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
     gatsby-core-utils "^1.10.0"
     gatsby-legacy-polyfills "^0.7.0"
-
-babel-preset-gatsby@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-gatsby/-/babel-preset-gatsby-0.8.0.tgz#3dc69d55b771c850f1c35a0a796430509738ed61"
-  integrity sha512-ea4qjDiqo6LJ4PISIEajpcrRH7kAbgDNKox8bDEdWT6xtWl1oEN760lby0oPQ5SWTbZf1D+U8xT7s0KEzrcA2w==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.12.1"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
-    "@babel/plugin-proposal-optional-chaining" "^7.12.1"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-transform-runtime" "^7.12.1"
-    "@babel/plugin-transform-spread" "^7.12.1"
-    "@babel/preset-env" "^7.12.1"
-    "@babel/preset-react" "^7.12.5"
-    "@babel/runtime" "^7.12.5"
-    babel-plugin-dynamic-import-node "^2.3.3"
-    babel-plugin-macros "^2.8.0"
-    babel-plugin-transform-react-remove-prop-types "^0.4.24"
-    gatsby-core-utils "^1.6.0"
-    gatsby-legacy-polyfills "^0.3.0"
 
 babel-preset-jest@^24.9.0:
   version "24.9.0"
@@ -4889,7 +4865,7 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
-chokidar@^2.0.4, chokidar@^2.1.8:
+chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -5450,11 +5426,6 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
-
-cookie@~0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
-  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -6574,23 +6545,6 @@ engine.io-client@~3.4.0:
     xmlhttprequest-ssl "~1.5.4"
     yeast "0.1.2"
 
-engine.io-client@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.5.0.tgz#fc1b4d9616288ce4f2daf06dcf612413dec941c7"
-  integrity sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==
-  dependencies:
-    component-emitter "~1.3.0"
-    component-inherit "0.0.3"
-    debug "~3.1.0"
-    engine.io-parser "~2.2.0"
-    has-cors "1.1.0"
-    indexof "0.0.1"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    ws "~7.4.2"
-    xmlhttprequest-ssl "~1.5.4"
-    yeast "0.1.2"
-
 engine.io-parser@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
@@ -6613,18 +6567,6 @@ engine.io@~3.4.0:
     debug "~4.1.0"
     engine.io-parser "~2.2.0"
     ws "^7.1.2"
-
-engine.io@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.5.0.tgz#9d6b985c8a39b1fe87cd91eb014de0552259821b"
-  integrity sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==
-  dependencies:
-    accepts "~1.3.4"
-    base64id "2.0.0"
-    cookie "~0.4.1"
-    debug "~4.1.0"
-    engine.io-parser "~2.2.0"
-    ws "~7.4.2"
 
 enhanced-resolve@^4.5.0:
   version "4.5.0"
@@ -7952,7 +7894,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gatsby-cli@^2.15.0, gatsby-cli@^2.19.1:
+gatsby-cli@^2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-2.19.1.tgz#869318650ddcb0d2eef9063a46d2c6fa8f77bdc2"
   integrity sha512-lJ+0HgcTGVmEzkaPVTeqVQUxpt3oW3ad0p1hcYzViVtjkGOBxIQdD11yJiC9ZvmKi9FWW7e/tFTdrMEylFLmIA==
@@ -7996,10 +7938,23 @@ gatsby-cli@^2.15.0, gatsby-cli@^2.19.1:
     yoga-layout-prebuilt "^1.9.6"
     yurnalist "^2.1.0"
 
-gatsby-core-utils@^1.1.1, gatsby-core-utils@^1.10.0, gatsby-core-utils@^1.6.0:
+gatsby-core-utils@^1.1.1, gatsby-core-utils@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.10.0.tgz#7df5bc7b7e810c71602d5ec18a925e8a7890fb45"
   integrity sha512-uI5gJXmVHegn8E/vttoX0BaXRJPC73RzxuZDtl2U5WBEgeg+VVkKCmNVQE9Xk+Qstm2Wd6RU+QJ4LMx5ywYZhQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
+gatsby-core-utils@^2.0.0-next.0:
+  version "2.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.0.0-next.0.tgz#d99ccee2b79418775d7cb201d566798dd48ede92"
+  integrity sha512-SOjvI4ojMjjfDbMo6nJwyaGvqkHbtnpB2deR6yOa0gaI52PhH1fARIvMGL8hg8FG0YCaAHjndqAPdgcLHJ/UVg==
   dependencies:
     ci-info "2.0.0"
     configstore "^5.0.1"
@@ -8016,13 +7971,6 @@ gatsby-graphiql-explorer@^0.11.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-gatsby-graphiql-explorer@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.7.0.tgz#7b98c51f4fc2b66064ce16aa107b8e34dc664fa0"
-  integrity sha512-CRgxnfxVHgWe2VmGdBC1E4ctXGP54215rIQ8/wTqClkGiRuKOg98h70vuekVdWQJnicbpJI05Ms1zPLlj9ckgg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 gatsby-image@^2.4.7:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.11.0.tgz#5bbd02c3dcf78291131de26da061b4180bb67e6e"
@@ -8032,13 +7980,6 @@ gatsby-image@^2.4.7:
     object-fit-images "^3.2.4"
     prop-types "^15.7.2"
 
-gatsby-legacy-polyfills@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-0.3.0.tgz#515e1d57416c87fe9a107baf63b53b37752d4193"
-  integrity sha512-bNXUzTAqGQq01zba4W00+XXxdu2uqYABytLZJv3HBJAIKUk/e9eO8KR9GEh3zIVIC8HQ++PSZapl9Afu0i4G1w==
-  dependencies:
-    core-js-compat "^3.6.5"
-
 gatsby-legacy-polyfills@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-0.7.0.tgz#8ef8aeeb59b6679920489edb2493ac16bcd03c82"
@@ -8046,7 +7987,7 @@ gatsby-legacy-polyfills@^0.7.0:
   dependencies:
     core-js-compat "^3.6.5"
 
-gatsby-link@^2.11.0, gatsby-link@^2.7.0:
+gatsby-link@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.11.0.tgz#15e99c89bdde1c99686ce53bda72beb3c9c39455"
   integrity sha512-AYXxndlSx5mnYv+/PBPdPBRvdv1LeSGE3WO8uYj2ReYDSbhiAlF3KKz30D62ErartXP0deySPtRKx4Dd3nCFYw==
@@ -8069,7 +8010,24 @@ gatsby-page-utils@^0.9.0:
     lodash "^4.17.20"
     micromatch "^4.0.2"
 
-gatsby-plugin-page-creator@^2.10.0, gatsby-plugin-page-creator@^2.6.0:
+gatsby-plugin-image@^1.0.0-next.3:
+  version "1.0.0-next.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-1.0.0-next.3.tgz#1f7e005d306f5a7abca02f20b2f205e5df1fdba2"
+  integrity sha512-1swpNxvMiVeuePlm0pnj0L9Onz0bnaqYXc69Z/NHKl6kHg+Q9uMZqnOMbnMnTHejteCshtlfJiLMvnTqBJaegA==
+  dependencies:
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
+    babel-jsx-utils "^1.0.1"
+    babel-plugin-remove-graphql-queries "^3.0.0-next.0"
+    camelcase "^5.3.1"
+    chokidar "^3.5.1"
+    common-tags "^1.8.0"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^2.0.0-next.0"
+    objectFitPolyfill "^2.3.0"
+    prop-types "^15.7.2"
+
+gatsby-plugin-page-creator@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.10.0.tgz#81adbe8b03ef46f1553bb5b68abd6c85d3c25433"
   integrity sha512-lOzHJpzKEs6DM8Jxci3VozNIxcCTDTwRP5ypK5+7Qx3TUVzcpW7MMgUiwLo9G1kznN2YPe9cuoiTj5wNBjdEfA==
@@ -8109,7 +8067,7 @@ gatsby-plugin-sharp@^2.3.13:
     svgo "1.3.2"
     uuid "3.4.0"
 
-gatsby-plugin-typescript@^2.12.0, gatsby-plugin-typescript@^2.8.0:
+gatsby-plugin-typescript@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-typescript/-/gatsby-plugin-typescript-2.12.0.tgz#44df6cfde747ab94c1984621e5bb749da94af959"
   integrity sha512-Gb8mPdIgAmlxb/EgH7h5ewq3nMJ+oU640AyfTCAp9GtQspRztRRKjuGceJH3gDVq8bO6wFOWxdRVYIC2KZF9mw==
@@ -8122,13 +8080,6 @@ gatsby-plugin-typescript@^2.12.0, gatsby-plugin-typescript@^2.8.0:
     "@babel/runtime" "^7.12.5"
     babel-plugin-remove-graphql-queries "^2.16.0"
 
-gatsby-plugin-utils@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-0.5.0.tgz#5d0c0b9589b673f422e09e3e2e80bafbe3457505"
-  integrity sha512-Wvzt970TWr+cDdFdXjFmJ5rQEk9CbbbHzGo5GHOwfphXOTwp7/oKbTZoiGBm9M9Tf9Rdz6ph18j2ixdC0fy2Jw==
-  dependencies:
-    joi "^17.2.1"
-
 gatsby-plugin-utils@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-0.9.0.tgz#64b35a0faaabad5b5c99ee8951a9c08cd64be289"
@@ -8136,7 +8087,7 @@ gatsby-plugin-utils@^0.9.0:
   dependencies:
     joi "^17.2.1"
 
-gatsby-react-router-scroll@^3.3.0, gatsby-react-router-scroll@^3.7.0:
+gatsby-react-router-scroll@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.7.0.tgz#4b519c517f09f263275d3ac9001efe3d1f2b5957"
   integrity sha512-8sm04EQac7fccJZlllFEo349wAlNEuPVu35juuL0hgMDTyWlk4nPwPH/ACdpn2MgpEmrTSfp2yPxyzaRKVyzeQ==
@@ -8226,7 +8177,7 @@ gatsby-source-filesystem@^2.1.46:
     valid-url "^1.0.9"
     xstate "^4.14.0"
 
-gatsby-telemetry@^1.10.0, gatsby-telemetry@^1.6.0:
+gatsby-telemetry@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-1.10.0.tgz#8c8552df575e66d58ca785554e47306d9cbe53d2"
   integrity sha512-lGUCwAASThIK5KtFwbVnQfthcKJRosxK70BrXy7c7h3FPSdbahy8DZvpuNz6beCAets3ZDGTXVzPGtzPZI1u6Q==
@@ -8246,165 +8197,7 @@ gatsby-telemetry@^1.10.0, gatsby-telemetry@^1.6.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
-gatsby@2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.28.0.tgz#ed2d3b1d1f953ff59f641797560df555a41bf1b2"
-  integrity sha512-kWejVSxsuiT/yfghLHDOeaJg0eV5UdS5zc66ANPcSEJ+9U3DgPWoVM18aFsa+VsywGWxp2uqzOPdsItjdiOt+A==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/core" "^7.12.3"
-    "@babel/parser" "^7.12.5"
-    "@babel/runtime" "^7.12.5"
-    "@babel/traverse" "^7.12.5"
-    "@babel/types" "^7.12.6"
-    "@hapi/joi" "^15.1.1"
-    "@mikaelkristiansson/domready" "^1.0.10"
-    "@nodelib/fs.walk" "^1.2.4"
-    "@pieh/friendly-errors-webpack-plugin" "1.7.0-chalk-2"
-    "@pmmmwh/react-refresh-webpack-plugin" "^0.4.1"
-    "@reach/router" "^1.3.4"
-    "@types/http-proxy" "^1.17.4"
-    "@typescript-eslint/eslint-plugin" "^2.24.0"
-    "@typescript-eslint/parser" "^2.24.0"
-    address "1.1.2"
-    anser "^2.0.1"
-    ansi-html "^0.0.7"
-    autoprefixer "^9.8.4"
-    axios "^0.20.0"
-    babel-core "7.0.0-bridge.0"
-    babel-eslint "^10.1.0"
-    babel-loader "^8.1.0"
-    babel-plugin-add-module-exports "^0.3.3"
-    babel-plugin-dynamic-import-node "^2.3.3"
-    babel-plugin-lodash "3.3.4"
-    babel-plugin-remove-graphql-queries "^2.12.0"
-    babel-preset-gatsby "^0.8.0"
-    better-opn "^2.0.0"
-    better-queue "^3.8.10"
-    bluebird "^3.7.2"
-    body-parser "^1.19.0"
-    browserslist "^4.12.2"
-    cache-manager "^2.11.1"
-    chalk "^4.1.0"
-    chokidar "^3.4.2"
-    common-tags "^1.8.0"
-    compression "^1.7.4"
-    convert-hrtime "^3.0.0"
-    copyfiles "^2.3.0"
-    core-js "^3.6.5"
-    cors "^2.8.5"
-    css-loader "^1.0.1"
-    date-fns "^2.14.0"
-    debug "^3.2.6"
-    del "^5.1.0"
-    detect-port "^1.3.0"
-    devcert "^1.1.3"
-    dotenv "^8.2.0"
-    eslint "^6.8.0"
-    eslint-config-react-app "^5.2.1"
-    eslint-loader "^2.2.1"
-    eslint-plugin-flowtype "^3.13.0"
-    eslint-plugin-graphql "^4.0.0"
-    eslint-plugin-import "^2.22.0"
-    eslint-plugin-jsx-a11y "^6.3.1"
-    eslint-plugin-react "^7.20.6"
-    eslint-plugin-react-hooks "^1.7.0"
-    event-source-polyfill "^1.0.15"
-    execa "^4.0.3"
-    express "^4.17.1"
-    express-graphql "^0.9.0"
-    fastest-levenshtein "^1.0.12"
-    file-loader "^1.1.11"
-    find-cache-dir "^3.3.1"
-    fs-exists-cached "1.0.0"
-    fs-extra "^8.1.0"
-    gatsby-cli "^2.15.0"
-    gatsby-core-utils "^1.6.0"
-    gatsby-graphiql-explorer "^0.7.0"
-    gatsby-legacy-polyfills "^0.3.0"
-    gatsby-link "^2.7.0"
-    gatsby-plugin-page-creator "^2.6.0"
-    gatsby-plugin-typescript "^2.8.0"
-    gatsby-plugin-utils "^0.5.0"
-    gatsby-react-router-scroll "^3.3.0"
-    gatsby-telemetry "^1.6.0"
-    glob "^7.1.6"
-    got "8.3.2"
-    graphql "^14.6.0"
-    graphql-compose "^6.3.8"
-    graphql-playground-middleware-express "^1.7.18"
-    hasha "^5.2.0"
-    http-proxy "^1.18.1"
-    invariant "^2.2.4"
-    is-relative "^1.0.0"
-    is-relative-url "^3.0.0"
-    jest-worker "^24.9.0"
-    joi "^17.2.1"
-    json-loader "^0.5.7"
-    json-stringify-safe "^5.0.1"
-    latest-version "5.1.0"
-    lodash "^4.17.20"
-    md5-file "^5.0.0"
-    meant "^1.0.1"
-    micromatch "^4.0.2"
-    mime "^2.4.6"
-    mini-css-extract-plugin "^0.11.2"
-    mitt "^1.2.0"
-    mkdirp "^0.5.1"
-    moment "^2.27.0"
-    name-all-modules-plugin "^1.0.1"
-    normalize-path "^3.0.0"
-    null-loader "^3.0.0"
-    opentracing "^0.14.4"
-    optimize-css-assets-webpack-plugin "^5.0.3"
-    p-defer "^3.0.0"
-    parseurl "^1.3.3"
-    physical-cpu-count "^2.0.0"
-    pnp-webpack-plugin "^1.6.4"
-    postcss-flexbugs-fixes "^4.2.1"
-    postcss-loader "^3.0.0"
-    prompts "^2.3.2"
-    prop-types "^15.7.2"
-    query-string "^6.13.1"
-    raw-loader "^0.5.1"
-    react-dev-utils "^4.2.3"
-    react-error-overlay "^3.0.0"
-    react-hot-loader "^4.12.21"
-    react-refresh "^0.8.3"
-    redux "^4.0.5"
-    redux-thunk "^2.3.0"
-    semver "^7.3.2"
-    shallow-compare "^1.2.2"
-    signal-exit "^3.0.3"
-    slugify "^1.4.4"
-    socket.io "^2.3.0"
-    socket.io-client "2.3.0"
-    source-map "^0.7.3"
-    source-map-support "^0.5.19"
-    st "^2.0.0"
-    stack-trace "^0.0.10"
-    string-similarity "^1.2.2"
-    style-loader "^0.23.1"
-    terminal-link "^2.1.1"
-    terser-webpack-plugin "^2.3.8"
-    tmp "^0.2.1"
-    "true-case-path" "^2.2.1"
-    type-of "^2.0.1"
-    url-loader "^1.1.2"
-    util.promisify "^1.0.1"
-    uuid "3.4.0"
-    v8-compile-cache "^1.1.2"
-    webpack "^4.44.1"
-    webpack-dev-middleware "^3.7.2"
-    webpack-dev-server "^3.11.0"
-    webpack-hot-middleware "^2.25.0"
-    webpack-merge "^4.2.2"
-    webpack-stats-plugin "^0.3.2"
-    webpack-virtual-modules "^0.2.2"
-    xstate "^4.11.0"
-    yaml-loader "^0.6.0"
-
-gatsby@^2.28.0:
+gatsby@^2.20.8, gatsby@^2.28.0:
   version "2.32.3"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.32.3.tgz#af4c12e676c9e0cdbc69c29508af2384da462c11"
   integrity sha512-6l1ktlIbj6dRDnAPi+dh/tAEx7FdEYm55RwM3aiFEpwNIHeevG+Jw1RZhIpwUmhkGBwaOjr559KJYf7dYuXk3w==
@@ -12616,6 +12409,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
+objectFitPolyfill@^2.3.0:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz#be8c83064aabfa4e88780f776c2013c48ce1f745"
+  integrity sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA==
+
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
@@ -15407,23 +15205,6 @@ socket.io-client@2.3.0:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
-socket.io-client@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.4.0.tgz#aafb5d594a3c55a34355562fc8aea22ed9119a35"
-  integrity sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==
-  dependencies:
-    backo2 "1.0.2"
-    component-bind "1.0.0"
-    component-emitter "~1.3.0"
-    debug "~3.1.0"
-    engine.io-client "~3.5.0"
-    has-binary2 "~1.0.2"
-    indexof "0.0.1"
-    parseqs "0.0.6"
-    parseuri "0.0.6"
-    socket.io-parser "~3.3.0"
-    to-array "0.1.4"
-
 socket.io-parser@~3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
@@ -15452,18 +15233,6 @@ socket.io@2.3.0:
     has-binary2 "~1.0.2"
     socket.io-adapter "~1.1.0"
     socket.io-client "2.3.0"
-    socket.io-parser "~3.4.0"
-
-socket.io@^2.3.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.4.1.tgz#95ad861c9a52369d7f1a68acf0d4a1b16da451d2"
-  integrity sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==
-  dependencies:
-    debug "~4.1.0"
-    engine.io "~3.5.0"
-    has-binary2 "~1.0.2"
-    socket.io-adapter "~1.1.0"
-    socket.io-client "2.4.0"
     socket.io-parser "~3.4.0"
 
 sockjs-client@1.1.4:
@@ -17147,11 +16916,6 @@ uuid@3.4.0, uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-v8-compile-cache@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
-  integrity sha512-ejdrifsIydN1XDH7EuR2hn8ZrkRKUYF7tUcBjBy/lhrCvs2K+zRlbW9UHc0IQ9RsYFZJFqJrieoIHfkCa0DBRA==
-
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
@@ -17293,7 +17057,7 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@^3.11.0, webpack-dev-server@^3.11.2:
+webpack-dev-server@^3.11.2:
   version "3.11.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz#695ebced76a4929f0d5de7fd73fafe185fe33708"
   integrity sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==
@@ -17653,7 +17417,7 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.1.2, ws@^7.3.0, ws@~7.4.2:
+ws@^7.1.2, ws@^7.3.0:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==


### PR DESCRIPTION
### Motivation

The next version of Gatsby will include [a new image plugin](https://www.gatsbyjs.com/docs/how-to/images-and-media/using-gatsby-plugin-image/) to replace `gatsby-image`. It follows latest best practices to deliver better performance and improved Lighthouse scores. The plugin includes a toolkit to allow plugin authors to add support to their plugins. This PR adds support to the Kontent plugin, via a new component which accepts an `image` object. This uses the Kontent image transformation API, so does not require image downloads. It works on its own, or via a RichTextElement. Usage is like this:

```jsx
import { ImageElement } from "@kentico/gatsby-kontent-components"
// ...
        <ImageElement
          image={data.author.elements.avatar_image.value[0]}
          width={200}
          height={200}
        />

```

It depends on the _next_  version of `gatsby-plugin-image`, so this should not be released until that is stable, which will be at the end of the month. This can be tested now as the dependency is targeting the nightly release.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

See the example site
