### PR TITLE
Webhooks improvements

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
     "!examples/*",
     "packages/*"
   ],
-  "version": "6.3.1"
+  "version": "6.3.2-alpha.0"
 }

--- a/packages/gatsby-source-kontent/gatsby-node.ts
+++ b/packages/gatsby-source-kontent/gatsby-node.ts
@@ -48,11 +48,13 @@ exports.sourceNodes = async (
 ): Promise<void> => {
   try {
     if (!_.isEmpty(api.webhookBody)) { //preview run
+      const itemTypes = (await api.cache.get('kontent-item-types')) || [];
       await handleIncomingWebhook(api, pluginConfig, itemTypes);
       return;
     }
-
-    itemTypes = await kontentItemsSourceNodes(api, pluginConfig);
+    
+    const itemTypes = await kontentItemsSourceNodes(api, pluginConfig);
+    await api.cache.set('kontent-item-types',  itemTypes);
 
     if (pluginConfig.includeTaxonomies) {
       await kontentTaxonomiesSourceNodes(api, pluginConfig);

--- a/packages/gatsby-source-kontent/package.json
+++ b/packages/gatsby-source-kontent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kentico/gatsby-source-kontent",
   "description": "Source plugin providing Kentico Kontent data from REST Delivery API",
-  "version": "6.3.1",
+  "version": "6.3.2-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "author": {

--- a/packages/gatsby-source-kontent/src/client.ts
+++ b/packages/gatsby-source-kontent/src/client.ts
@@ -97,8 +97,8 @@ const loadAllKontentItems = async (
 ): Promise<KontentItemInput[]> => {
   let continuationToken = '';
   const items = [];
-  const headers = ensureAuthorizationHeader(config);
-  ensureTrackingHeader(headers);
+  let headers = ensureAuthorizationHeader(config);
+  headers = ensureTrackingHeader(headers);
   do {
     headers[continuationHeaderName] = continuationToken;
 
@@ -136,10 +136,10 @@ const loadKontentItem = async (
   modularKontent: { [key: string]: KontentItemInput };
 }> => {
 
-  const headers = ensureAuthorizationHeader(config);
-  ensureTrackingHeader(headers);
+  let  headers = ensureAuthorizationHeader(config);
+  headers = ensureTrackingHeader(headers);
   if (waitForLoadingNewContent) {
-    ensureNewContentHeader(headers)
+    headers = ensureNewContentHeader(headers)
   }
 
   const response = await axios.get(
@@ -163,8 +163,8 @@ const loadKontentItem = async (
 const loadAllKontentTypes = async (
   config: CustomPluginOptions,
 ): Promise<KontentType[]> => {
-  const headers = ensureAuthorizationHeader(config);
-  ensureTrackingHeader(headers);
+  let headers = ensureAuthorizationHeader(config);
+  headers = ensureTrackingHeader(headers);
   const response = await axios.get(
     `${getProtocolAndDomain(config)}/${config.projectId}/types`,
     {
@@ -193,8 +193,8 @@ const loadAllKontentTypesCached = async (
 const loadAllKontentTaxonomies = async (
   config: CustomPluginOptions,
 ): Promise<KontentTaxonomy[]> => {
-  const headers = ensureAuthorizationHeader(config);
-  ensureTrackingHeader(headers);
+  let headers = ensureAuthorizationHeader(config);
+  headers = ensureTrackingHeader(headers);
   const response = await axios.get(
     `${getProtocolAndDomain(config)}/${config.projectId}/taxonomies`,
     {

--- a/packages/gatsby-source-kontent/src/webhookProcessor.ts
+++ b/packages/gatsby-source-kontent/src/webhookProcessor.ts
@@ -191,12 +191,12 @@ const handleIncomingWebhook = async (
 
     if (webhook.message.operation === "upsert" || webhook.message.operation === "restore") {
       const processedIds = await handleUpsertItem(api, pluginConfig);
-      processedItemIds.concat(processedIds);
+      processedItemIds.push(...processedIds);
     }
 
     if (webhook.message.operation === "archive") {
       const processedIds = await handleDeleteItem(api, pluginConfig);
-      processedItemIds.concat(processedIds);
+      processedItemIds.push(...processedIds);
     }
   } else if (webhook.message.api_name === 'delivery_production') {
 
@@ -206,12 +206,12 @@ const handleIncomingWebhook = async (
 
     if (webhook.message.operation === "publish") {
       const processedIds = await handleUpsertItem(api, pluginConfig);
-      processedItemIds.concat(processedIds);
+      processedItemIds.push(...processedIds);
     }
 
     if (webhook.message.operation === "unpublish") {
       const processedIds = await handleDeleteItem(api, pluginConfig);
-      processedItemIds.concat(processedIds);
+      processedItemIds.push(...processedIds);
     }
   } else {
     api.reporter.verbose(`Webhook is not supported yet!`);
@@ -222,7 +222,7 @@ const handleIncomingWebhook = async (
   for (const itemType of itemTypes) {
     const itemsToTouch = api.getNodesByType(itemType);
     itemsToTouch
-      .filter(item => processedItemIds.includes(item.id))
+      .filter(item => !processedItemIds.includes(item.id))
       .forEach(itemToTouch => api.actions.touchNode({ nodeId: itemToTouch.id }))
   }
 

--- a/packages/gatsby-source-kontent/tests/pluginOptionsSchema.spec.ts
+++ b/packages/gatsby-source-kontent/tests/pluginOptionsSchema.spec.ts
@@ -45,7 +45,6 @@ describe(`pluginOptionsSchema`, () => {
       options
     )
 
-    console.log(errors);
     expect(isValid).toBe(true)
     expect(errors).toEqual([])
   })


### PR DESCRIPTION
### Motivation

@ondrabus was unhappy with the webhook processor code.

* `processedItems` in the webhook processor were not taking into account (`concat` creates a new array instead of modifying the caller)
* there should be a standard gatsby cache used for content types
* request headers should contain a cleaner set up in client

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
