### PR TITLE
fix(richtext image schema): make width and height optional

### DIFF
--- a/packages/gatsby-source-kontent/src/template.items.schema.gql
+++ b/packages/gatsby-source-kontent/src/template.items.schema.gql
@@ -108,8 +108,8 @@ type __KONTENT_ELEMENT_RICH_TEXT_IMAGE_VALUE__ {
   image_id: String!
   url: String!
   description: String
-  height: Int!
-  width: Int!
+  height: Int
+  width: Int
 }
 
 type __KONTENT_ELEMENT_RICH_TEXT_LINK_VALUE__ {

--- a/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
+++ b/packages/gatsby-source-kontent/tests/__snapshots__/createSchemaCustomization.items.spec.ts.snap
@@ -126,8 +126,8 @@ type kontent_item_rich_text_element_image {
   image_id: String!
   url: String!
   description: String
-  height: Int!
-  width: Int!
+  height: Int
+  width: Int
 }
 
 type kontent_item_rich_text_element_link {


### PR DESCRIPTION
### Motivation

https://github.com/Kentico/kontent-gatsby-packages/issues/177

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

Note: Once it's merged, I'll cherrypick it into https://github.com/Kentico/kontent-gatsby-packages/pull/174
